### PR TITLE
fix: remove unreachable fallback in castle sound theme mapping

### DIFF
--- a/lib/sound-manager.ts
+++ b/lib/sound-manager.ts
@@ -329,7 +329,7 @@ class SoundManager {
       "move": `${themePath}/Move.mp3`,
       "opponent-move": `${themePath}/Move.mp3`,
       "capture": `${themePath}/Capture.mp3`,
-      "castle": themeName === 'standard' ? "/sounds/lisp/Castles.mp3" : `${themePath}/Castles.mp3` || `${themePath}/Move.mp3`,
+      "castle": themeName === 'standard' ? "/sounds/lisp/Castles.mp3" : `${themePath}/Castles.mp3`,
       "check": `${themePath}/Check.mp3`,
       "promote": `${themePath}/Checkmate.mp3`,
       "draw-offer": `${themePath}/GenericNotify.mp3`,


### PR DESCRIPTION
Fixes ESLint error `no-constant-binary-expression` in sound-manager.ts by removing unreachable fallback logic.

The template literal `${themePath}/Castles.mp3` is always truthy, making the `|| ${themePath}/Move.mp3` fallback unreachable.

Generated with [Claude Code](https://claude.ai/code)