### PR TITLE
fix: correct Add Time button display logic and refactor player cards UI

### DIFF
--- a/components/game/GameSidebar.tsx
+++ b/components/game/GameSidebar.tsx
@@ -56,12 +56,12 @@ export default function GameSidebar({
   // Determine if player can give time (only to opponent, only if they're playing)
   const canGiveTimeToTop =
     isPlayer &&
-    ((role === "white" && !playerIsWhite) ||
-      (role === "black" && playerIsWhite));
-  const canGiveTimeToBottom =
-    isPlayer &&
     ((role === "white" && playerIsWhite) ||
       (role === "black" && !playerIsWhite));
+  const canGiveTimeToBottom =
+    isPlayer &&
+    ((role === "white" && !playerIsWhite) ||
+      (role === "black" && playerIsWhite));
 
   return (
     <div className="bg-background-secondary rounded-lg p-4 flex flex-col shadow-lg h-fit">
@@ -77,6 +77,8 @@ export default function GameSidebar({
           !gameState.gameOver
         }
         onGiveTime={onGiveTime}
+        rating={topPlayer === "Waiting..." ? undefined : 2051}
+        isOnline={topPlayer !== "Waiting..."}
       />
       <div className="my-2 border-t border-border"></div>
       {/* Fixed height for 4 rows of moves (approximately 120px) */}
@@ -101,6 +103,8 @@ export default function GameSidebar({
           !gameState.gameOver
         }
         onGiveTime={onGiveTime}
+        rating={bottomPlayer === "Waiting..." ? undefined : 2071}
+        isOnline={bottomPlayer !== "Waiting..."}
       />
       <div className="my-2 border-t border-border"></div>
       {onResign && !gameState.gameOver && isPlayer && (

--- a/components/game/PlayerInfo.tsx
+++ b/components/game/PlayerInfo.tsx
@@ -11,9 +11,11 @@ interface PlayerInfoProps {
   isClockActive?: boolean;
   canGiveTime?: boolean;
   onGiveTime?: () => void;
+  rating?: number;
+  isOnline?: boolean;
 }
 
-export default function PlayerInfo({ username, isTurn, clock, isClockActive = false, canGiveTime = false, onGiveTime }: PlayerInfoProps) {
+export default function PlayerInfo({ username, isTurn, clock, isClockActive = false, canGiveTime = false, onGiveTime, rating, isOnline = true }: PlayerInfoProps) {
   const { formattedTime, isLowTime, isCritical } = useGameTimer({
     clock,
     isActive: isClockActive,
@@ -41,27 +43,36 @@ export default function PlayerInfo({ username, isTurn, clock, isClockActive = fa
   };
 
   return (
-    <div className={`p-3 rounded-lg ${isTurn ? 'bg-primary/20' : 'bg-transparent'}`}>
-      <div className="flex items-center justify-between">
-        <span className={`font-semibold text-lg ${isTurn ? 'text-foreground' : 'text-foreground-muted'}`}>
-          {username}
-        </span>
+    <div className="py-2">
+      <div className="flex items-center justify-between mb-1">
         <div className="flex items-center gap-2">
-          <div className={getClockClassName()}>
-            {clock ? formattedTime : '5:00'}
-          </div>
-          {canGiveTime && onGiveTime && (
-            <button
-              onClick={onGiveTime}
-              className="p-2 rounded-md hover:bg-primary/20 transition-colors group"
-              title="Give 15 seconds to opponent"
-              aria-label="Give time to opponent"
-            >
-              <Plus className="w-4 h-4 text-foreground-muted group-hover:text-primary" />
-            </button>
+          <div className={`w-2 h-2 rounded-full ${isOnline ? 'bg-green-500' : 'bg-gray-400'}`} />
+          <span className={`font-medium text-base ${isTurn ? 'text-white' : 'text-gray-300'}`}>
+            {username}
+          </span>
+          {rating && (
+            <span className="text-sm text-gray-400">
+              {rating}
+            </span>
           )}
         </div>
+        {canGiveTime && onGiveTime && (
+          <button
+            onClick={onGiveTime}
+            className="p-1 rounded bg-blue-600 hover:bg-blue-500 transition-colors"
+            title="Give 15 seconds to opponent"
+            aria-label="Give time to opponent"
+          >
+            <Plus className="w-4 h-4 text-white" />
+          </button>
+        )}
       </div>
+      <div className={getClockClassName()}>
+        {clock ? formattedTime : '5:00'}
+      </div>
+      {isTurn && (
+        <div className="w-full h-0.5 bg-green-500 mt-1 rounded-full"></div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Closes #22

## Changes
- Fix Add Time button to show on opponent's profile instead of user's own
- Refactor player cards to match provided design mockup
- Add green dot indicators for online status
- Add rating display with placeholder values
- Improve typography and spacing
- Add active player indicator

Generated with [Claude Code](https://claude.ai/code)