### PR TITLE
feat: add truly offline local game mode

### DIFF
--- a/app/play/local/page.tsx
+++ b/app/play/local/page.tsx
@@ -1,25 +1,128 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 import { useGameState } from '@/hooks/useGameState';
+import { useOfflineGame } from '@/hooks/useOfflineGame';
+import { Wifi, WifiOff } from 'lucide-react';
 
 export default function PlayLocalPage() {
+  const [selectedMode, setSelectedMode] = useState<'online' | 'offline' | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+  
   const { connected, createSoloGame } = useGameState();
+  const { createOfflineGame } = useOfflineGame();
+  const router = useRouter();
 
+  // Auto-create online solo game if in creating state and connected
   useEffect(() => {
-    if (!connected) return;
+    if (selectedMode === 'online' && isCreating && connected) {
+      createSoloGame();
+    }
+  }, [selectedMode, isCreating, connected, createSoloGame]);
 
-    // Create solo game immediately when connected
-    // The useGameState hook will handle the redirect when it receives solo-game-created
-    createSoloGame();
-  }, [connected, createSoloGame]);
+  const handleOnlineMode = () => {
+    setSelectedMode('online');
+    setIsCreating(true);
+  };
+
+  const handleOfflineMode = () => {
+    setSelectedMode('offline');
+    setIsCreating(true);
+    
+    // Navigate to the offline game page - the game will be created there
+    const offlineGameId = `offline-${Date.now()}`;
+    router.push(`/game/${offlineGameId}?mode=offline`);
+  };
+
+  // Show loading state when creating
+  if (isCreating) {
+    const message = selectedMode === 'online' 
+      ? (connected ? 'Creating online solo game...' : 'Connecting to server...')
+      : 'Creating offline game...';
+      
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="text-center">
+          <div className="loading-spinner mb-4"></div>
+          <h2 className="text-2xl font-bold mb-2">
+            {selectedMode === 'online' ? 'Online Solo Game' : 'Offline Game'}
+          </h2>
+          <p className="text-foreground-muted">{message}</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex items-center justify-center min-h-[60vh]">
-      <div className="text-center">
-        <div className="loading-spinner mb-4"></div>
-        <h2 className="text-2xl font-bold mb-2">Creating Solo Game</h2>
-        <p className="text-foreground-muted">Setting up your practice game...</p>
+      <div className="max-w-md w-full mx-auto">
+        <div className="text-center mb-8">
+          <h1 className="text-3xl font-bold mb-2">Choose Game Mode</h1>
+          <p className="text-foreground-muted">
+            Select how you'd like to play your solo practice game
+          </p>
+        </div>
+
+        <div className="space-y-4">
+          {/* Online Mode */}
+          <button
+            onClick={handleOnlineMode}
+            disabled={!connected}
+            className="w-full p-6 rounded-lg border-2 border-border hover:border-primary transition-colors disabled:opacity-50 disabled:cursor-not-allowed bg-background-secondary hover:bg-background-tertiary"
+          >
+            <div className="flex items-center gap-4">
+              <div className="p-3 rounded-lg bg-primary/10">
+                <Wifi className="w-6 h-6 text-primary" />
+              </div>
+              <div className="flex-1 text-left">
+                <h3 className="text-lg font-semibold mb-1">Online Solo Game</h3>
+                <p className="text-sm text-foreground-muted">
+                  Server-managed game (current behavior)
+                  <br />
+                  <span className="text-xs">
+                    Uses server for validation, testing, and debugging
+                  </span>
+                </p>
+                {!connected && (
+                  <p className="text-xs text-destructive mt-1">
+                    Server connection required
+                  </p>
+                )}
+              </div>
+            </div>
+          </button>
+
+          {/* Offline Mode */}
+          <button
+            onClick={handleOfflineMode}
+            className="w-full p-6 rounded-lg border-2 border-border hover:border-primary transition-colors bg-background-secondary hover:bg-background-tertiary"
+          >
+            <div className="flex items-center gap-4">
+              <div className="p-3 rounded-lg bg-success/10">
+                <WifiOff className="w-6 h-6 text-success" />
+              </div>
+              <div className="flex-1 text-left">
+                <h3 className="text-lg font-semibold mb-1">Offline Game</h3>
+                <p className="text-sm text-foreground-muted">
+                  Pure local game using ban-chess.ts
+                  <br />
+                  <span className="text-xs">
+                    No server required, fully offline gameplay
+                  </span>
+                </p>
+              </div>
+            </div>
+          </button>
+        </div>
+
+        <div className="mt-8 text-center">
+          <p className="text-xs text-foreground-muted">
+            Both modes support the full 2ban-2chess experience.
+            <br />
+            Online mode is useful for testing server features.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/hooks/useOfflineGame.tsx
+++ b/hooks/useOfflineGame.tsx
@@ -1,0 +1,250 @@
+"use client";
+
+import { useState, useCallback, useMemo, useRef } from "react";
+import { BanChess } from "ban-chess.ts";
+import type {
+  SimpleGameState,
+  Action,
+  HistoryEntry,
+  GameEvent,
+  Square,
+  Move,
+  Ban,
+} from "@/lib/game-types";
+import soundManager from "@/lib/sound-manager";
+import { useAuth } from "@/components/AuthProvider";
+
+export function useOfflineGame() {
+  const { user } = useAuth();
+  const [game, setGame] = useState<BanChess | null>(null);
+  const [gameState, setGameState] = useState<SimpleGameState | null>(null);
+  const [gameEvents, setGameEvents] = useState<GameEvent[]>([]);
+  const [gameId, setGameId] = useState<string | null>(null);
+  
+  const previousFen = useRef<string | null>(null);
+
+  // Get current state from BanChess instance
+  const activePlayer = game?.getActivePlayer();
+  const actionType = game?.getActionType();
+  const ply = game?.getPly();
+  
+  // Convert legal actions to dests map for Chessground
+  const dests = useMemo(() => {
+    const destsMap = new Map<Square, Square[]>();
+    if (!game) return destsMap;
+    
+    const actions = game.getLegalActions();
+    actions.forEach((action) => {
+      // Convert Action object to BCN format string
+      const serialized = BanChess.serializeAction(action);
+      // Parse BCN format (e.g., "b:e2e4" or "m:d2d4")
+      const parts = serialized.split(":");
+      if (parts.length === 2) {
+        const moveStr = parts[1]; // e.g., "e2e4"
+        if (moveStr.length >= 4) {
+          const from = moveStr.substring(0, 2) as Square;
+          const to = moveStr.substring(2, 4) as Square;
+          
+          if (!destsMap.has(from)) {
+            destsMap.set(from, []);
+          }
+          destsMap.get(from)!.push(to);
+        }
+      }
+    });
+    
+    return destsMap;
+  }, [game]);
+
+  const createOfflineGame = useCallback((gameIdToUse?: string) => {
+    const newGameId = gameIdToUse || `offline-${Date.now()}`;
+    const banChessInstance = new BanChess();
+    
+    setGame(banChessInstance);
+    setGameId(newGameId);
+    
+    // Create minimal game state for UI compatibility
+    const username = user?.username || "Player";
+    setGameState({
+      fen: banChessInstance.fen(),
+      gameId: newGameId,
+      players: {
+        white: { id: user?.userId || "offline-white", username },
+        black: { id: user?.userId || "offline-black", username },
+      },
+      activePlayer: banChessInstance.getActivePlayer(),
+      ply: banChessInstance.getPly(),
+      gameOver: false,
+      history: [],
+    });
+    
+    setGameEvents([]);
+    previousFen.current = banChessInstance.fen();
+    
+    // Play game start sound
+    soundManager.playEvent("game-start");
+    
+    console.log("[OfflineGame] Created new offline game:", newGameId);
+  }, [user]);
+
+  const sendAction = useCallback((action: Action) => {
+    if (!game || !gameState) {
+      console.warn("[OfflineGame] No active game to send action to");
+      return;
+    }
+
+    try {
+      let move: Move | undefined;
+      let ban: Ban | undefined;
+
+      if ('move' in action) {
+        move = action.move;
+        // Apply move to BanChess instance
+        const moveResult = game.move(move.from, move.to, move.promotion);
+        if (!moveResult) {
+          console.warn("[OfflineGame] Invalid move:", move);
+          return;
+        }
+      } else if ('ban' in action) {
+        ban = action.ban;
+        // Apply ban to BanChess instance
+        const banResult = game.ban(ban.from, ban.to);
+        if (!banResult) {
+          console.warn("[OfflineGame] Invalid ban:", ban);
+          return;
+        }
+      }
+
+      // Update game state with new position
+      const newFen = game.fen();
+      const newActivePlayer = game.getActivePlayer();
+      const newPly = game.getPly();
+      const isGameOver = game.isGameOver();
+      
+      setGameState(prevState => ({
+        ...prevState!,
+        fen: newFen,
+        activePlayer: newActivePlayer,
+        ply: newPly,
+        gameOver: isGameOver,
+        result: isGameOver ? game.getResult() : undefined,
+      }));
+
+      // Add event to game events
+      const eventType = move ? "move-made" : "ban-made";
+      const eventMessage = move 
+        ? `Move: ${move.from}-${move.to}${move.promotion ? '=' + move.promotion : ''}`
+        : `Ban: ${ban!.from}-${ban!.to}`;
+        
+      const gameEvent: GameEvent = {
+        timestamp: Date.now(),
+        type: eventType,
+        message: eventMessage,
+        player: activePlayer,
+        metadata: move ? { move } : { ban },
+      };
+      
+      setGameEvents(prev => [...prev, gameEvent]);
+
+      // Play sound effects
+      if (previousFen.current && newFen !== previousFen.current) {
+        const prevPieces = (previousFen.current.match(/[prnbqk]/gi) || []).length;
+        const currentPieces = (newFen.match(/[prnbqk]/gi) || []).length;
+        
+        soundManager.playMoveSound({
+          check: game.isInCheck(),
+          capture: currentPieces < prevPieces,
+        });
+      }
+      
+      previousFen.current = newFen;
+
+      // Handle game over
+      if (isGameOver) {
+        const result = game.getResult();
+        console.log("[OfflineGame] Game Over:", result);
+        
+        soundManager.playEvent("game-end", {
+          result: result || "Game ended",
+          playerRole: "both", // In offline mode, user plays both sides
+        });
+        
+        // Add game over event
+        const gameOverEvent: GameEvent = {
+          timestamp: Date.now(),
+          type: game.isCheckmate() ? "checkmate" : 
+                game.isStalemate() ? "stalemate" : "draw",
+          message: result || "Game ended",
+          metadata: { result: result || "Game ended" },
+        };
+        
+        setGameEvents(prev => [...prev, gameOverEvent]);
+      }
+
+      console.log("[OfflineGame] Action processed:", {
+        action,
+        newFen,
+        newActivePlayer,
+        newPly,
+        isGameOver
+      });
+      
+    } catch (error) {
+      console.error("[OfflineGame] Error processing action:", error);
+    }
+  }, [game, gameState, activePlayer]);
+
+  const resignGame = useCallback(() => {
+    if (!gameState || gameState.gameOver) {
+      return;
+    }
+
+    setGameState(prevState => ({
+      ...prevState!,
+      gameOver: true,
+      result: `${activePlayer === 'white' ? 'Black' : 'White'} wins by resignation`,
+    }));
+
+    const resignEvent: GameEvent = {
+      timestamp: Date.now(),
+      type: "resignation",
+      message: `${activePlayer === 'white' ? 'White' : 'Black'} resigned`,
+      player: activePlayer,
+    };
+    
+    setGameEvents(prev => [...prev, resignEvent]);
+
+    soundManager.playEvent("game-end", {
+      result: `${activePlayer === 'white' ? 'Black' : 'White'} wins by resignation`,
+      playerRole: "both",
+    });
+
+    console.log("[OfflineGame] Game resigned");
+  }, [gameState, activePlayer]);
+
+  const isOfflineGame = useMemo(() => {
+    return gameId?.startsWith("offline-") || false;
+  }, [gameId]);
+
+  return {
+    // State
+    gameState,
+    game,
+    dests,
+    activePlayer,
+    actionType,
+    ply,
+    gameEvents,
+    gameId,
+    isOfflineGame,
+
+    // Actions
+    createOfflineGame,
+    sendAction,
+    resignGame,
+
+    // Status
+    connected: true, // Offline games are always "connected"
+    error: null,
+  };
+}


### PR DESCRIPTION
TBI: Add offline game mode that uses ban-chess.ts locally without server communication

Resolves #24

- Create useOfflineGame hook for pure local BanChess gameplay
- Update local play page with online/offline mode selection
- Enhance GameClient to handle both online and offline games
- Maintain full compatibility with existing online solo mode
- Enable completely offline gameplay without server dependency

Generated with [Claude Code](https://claude.ai/code)