### PR TITLE
fix: remove broken legacy move reference

### DIFF
--- a/hooks/useGameState.tsx
+++ b/hooks/useGameState.tsx
@@ -275,13 +275,10 @@ export function useGameState() {
               if (msg.lastMove) {
                 wasBan = msg.lastMove.actionType === "ban";
                 if (msg.lastMove.actionType === "move") {
-                  // Handle move action - could be either { move: Move } or direct Move
+                  // Handle move action - should always be { move: Move }
                   let move;
                   if ("move" in msg.lastMove.action) {
                     move = msg.lastMove.action.move;
-                  } else {
-                    // Direct move object (legacy format)
-                    move = msg.lastMove.action as Move;
                   }
                   
                   if (move) {


### PR DESCRIPTION
Removed the broken attempt at backwards compatibility for legacy move format.
The code was trying to cast msg.lastMove.action to an undefined Move type.
Since there's no such thing as a legacy move format in this context,
removed the problematic else clause entirely.

Closes #28

Generated with [Claude Code](https://claude.ai/code)