### PR TITLE
fix: correct prisma import paths in server files

### DIFF
--- a/server/auth-validation.ts
+++ b/server/auth-validation.ts
@@ -1,7 +1,7 @@
 import type { IncomingMessage } from 'http';
-import type { AuthProvider } from '../types/auth';
+import type { AuthProvider } from '@/types/auth';
 import { decode } from 'next-auth/jwt';
-import prisma from '../lib/prisma';
+import prisma from '@/lib/prisma';
 
 interface AuthToken {
   username: string;

--- a/server/redis.ts
+++ b/server/redis.ts
@@ -1,5 +1,5 @@
 import Redis from "ioredis";
-import type { TimeControl, GameEvent } from "../lib/game-types";
+import type { TimeControl, GameEvent } from "@/lib/game-types";
 
 // Type definitions for Redis data structures
 export interface GameStateData {

--- a/server/time-manager.ts
+++ b/server/time-manager.ts
@@ -1,4 +1,4 @@
-import type { TimeControl, PlayerClock } from '../lib/game-types';
+import type { TimeControl, PlayerClock } from '@/lib/game-types';
 
 export class TimeManager {
   private timeControl: TimeControl;

--- a/server/ws-server.ts
+++ b/server/ws-server.ts
@@ -14,7 +14,7 @@ import type {
   TimeControl,
   GameEvent,
   PlayerClock,
-} from "../lib/game-types";
+} from "@/lib/game-types";
 import { v4 as uuidv4 } from "uuid";
 import { TimeManager } from "./time-manager";
 import { validateNextAuthToken } from "./auth-validation";


### PR DESCRIPTION
Use TypeScript path mapping (@/lib/prisma) instead of relative imports
to fix 'Cannot find module ../lib/prisma' error. This ensures consistency
with the project's configured path mapping in tsconfig.json.

Fixes #37

Generated with [Claude Code](https://claude.ai/code)